### PR TITLE
support for NextClear

### DIFF
--- a/bitset.go
+++ b/bitset.go
@@ -54,6 +54,7 @@ import (
 
 // Word size of a bit set
 const wordSize = uint(64)
+const allBits uint64 = 0xffffffffffffffff
 
 // for laster arith.
 const log2WordSize = uint(6)
@@ -147,6 +148,29 @@ func (b *BitSet) Flip(i uint) *BitSet {
 	}
 	b.set[i>>log2WordSize] ^= 1 << (i & (wordSize - 1))
 	return b
+}
+
+// return the next clear bit from the specified index, including possibly the current index
+// along with an error code (true = valid, false = no bit found i.e. all bits are set)
+func (b *BitSet) NextClear(i uint) (uint, bool) {
+	x := int(i >> log2WordSize)
+	if x >= len(b.set) {
+		return 0, false
+	}
+	w := b.set[x]
+	w = w >> (i & (wordSize - 1))
+	wA := allBits >> (i & (wordSize -1))
+	if w != wA {
+		return i + trailingZeroes64(^w), true
+	}
+	x = x + 1
+	for x < len(b.set) {
+		if b.set[x] != allBits {
+			return uint(x)*wordSize + trailingZeroes64(^b.set[x]), true
+		}
+		x = x + 1
+	}
+	return 0, false
 }
 
 // return the next bit set from the specified index, including possibly the current index
@@ -463,7 +487,6 @@ func (b *BitSet) isEven() bool {
 func (b *BitSet) cleanLastWord() {
 	if !b.isEven() {
 		// Mask for cleaning last word
-		const allBits uint64 = 0xffffffffffffffff
 		b.set[wordsNeeded(b.length)-1] &= allBits >> (wordSize - b.length%wordSize)
 	}
 }

--- a/bitset_test.go
+++ b/bitset_test.go
@@ -97,6 +97,46 @@ func TestBitSetAndGet(t *testing.T) {
 	}
 }
 
+func TestNextClear(t *testing.T) {
+    v := New(1000)
+    v.Set(0).Set(1)
+	next, found := v.NextClear(0)
+    if !found || next != 2 {
+        t.Errorf("Found next clear bit as %d, it should have been 2", next)
+    }
+
+    v = New(1000)
+    for i := uint(0); i < 66; i++ {
+        v.Set(i)
+    }
+	next, found = v.NextClear(0)
+    if !found || next != 66 {
+        t.Errorf("Found next clear bit as %d, it should have been 66", next)
+    }
+
+    v = New(1000)
+    for i := uint(0); i < 64; i++ {
+        v.Set(i)
+    }
+    v.Clear(45)
+    v.Clear(52)
+	next, found = v.NextClear(10)
+    if !found || next != 45 {
+        t.Errorf("Found next clear bit as %d, it should have been 45", next)
+    }
+
+    v = New(1000)
+    for i := uint(0); i < 128; i++ {
+        v.Set(i)
+    }
+    v.Clear(73)
+    v.Clear(99)
+	next, found = v.NextClear(10)
+    if !found || next != 73 {
+        t.Errorf("Found next clear bit as %d, it should have been 73", next)
+    }
+}
+
 func TestIterate(t *testing.T) {
 	v := New(10000)
 	v.Set(0)


### PR DESCRIPTION
This PR fixes the issue #25 
Instead of calling NextSet, I chose NextClear. 

I am not very well versed with the DeBruijn sequences, but I hope finding a clear bit would be equivalent to finding a set bit in compliment of a word.
