### PR TITLE
Fix bug in IsSuperSet

### DIFF
--- a/bitset.go
+++ b/bitset.go
@@ -511,8 +511,8 @@ func (b *BitSet) Any() bool {
 
 // IsSuperSet returns true if this is a superset of the other set
 func (b *BitSet) IsSuperSet(other *BitSet) bool {
-	for i, e := b.NextSet(0); e; i, e = b.NextSet(i + 1) {
-		if !other.Test(i) {
+	for i, e := other.NextSet(0); e; i, e = other.NextSet(i + 1) {
+		if !b.Test(i) {
 			return false
 		}
 	}

--- a/bitset_test.go
+++ b/bitset_test.go
@@ -640,14 +640,56 @@ func TestComplement(t *testing.T) {
 func TestIsSuperSet(t *testing.T) {
 	a := New(500)
 	b := New(300)
-	for i := uint(0); i < 200; i++ {
+	c := New(200)
+
+	// Setup bitsets
+	// a and b overlap
+	// only c is (strict) super set
+	for i := uint(0); i < 100; i++ {
 		a.Set(i)
+	}
+	for i := uint(50); i < 150; i++ {
 		b.Set(i)
 	}
-	if a.IsSuperSet(b) != true {
+	for i := uint(0); i < 200; i++ {
+		c.Set(i)
+	}
+
+	if a.IsSuperSet(b) == true {
 		t.Errorf("IsSuperSet fails")
 	}
-	if a.IsStrictSuperSet(b) != false {
+	if a.IsSuperSet(c) == true {
+		t.Errorf("IsSuperSet fails")
+	}
+	if b.IsSuperSet(a) == true {
+		t.Errorf("IsSuperSet fails")
+	}
+	if b.IsSuperSet(c) == true {
+		t.Errorf("IsSuperSet fails")
+	}
+	if c.IsSuperSet(a) != true {
+		t.Errorf("IsSuperSet fails")
+	}
+	if c.IsSuperSet(b) != true {
+		t.Errorf("IsSuperSet fails")
+	}
+
+	if a.IsStrictSuperSet(b) == true {
+		t.Errorf("IsStrictSuperSet fails")
+	}
+	if a.IsStrictSuperSet(c) == true {
+		t.Errorf("IsStrictSuperSet fails")
+	}
+	if b.IsStrictSuperSet(a) == true {
+		t.Errorf("IsStrictSuperSet fails")
+	}
+	if b.IsStrictSuperSet(c) == true {
+		t.Errorf("IsStrictSuperSet fails")
+	}
+	if c.IsStrictSuperSet(a) != true {
+		t.Errorf("IsStrictSuperSet fails")
+	}
+	if c.IsStrictSuperSet(b) != true {
 		t.Errorf("IsStrictSuperSet fails")
 	}
 }


### PR DESCRIPTION
In IsSuperSet, the "other" set has to be traversed and compared to the current instance, the reverse is wrong. Test has been updated to reflect this change. Updates #30.