### PR TITLE
Proposal to stop a possible panic:

### DIFF
--- a/bitset.go
+++ b/bitset.go
@@ -90,8 +90,22 @@ func wordsNeeded(i uint) int {
 }
 
 // New creates a new BitSet with a hint that length bits will be required
-func New(length uint) *BitSet {
-	return &BitSet{length, make([]uint64, wordsNeeded(length))}
+func New(length uint) (bset *BitSet) {
+	defer func() {
+		if r := recover(); r != nil {
+			bset = &BitSet{
+				0,
+				make([]uint64, 0),
+			}
+		}
+	}()
+
+	bset = &BitSet{
+		length,
+		make([]uint64, wordsNeeded(length)),
+	}
+
+	return bset
 }
 
 // Cap returns the total possible capicity, or number of bits


### PR DESCRIPTION
In function `New(length uint) *BitSet`, it's possible to get a panic when giving it a value that is too big.

This a big problem for those of us who use the `bloom` package because the panic can occur when invalid files are passed in, or other manipulations where the cause -> effect isn't easily traceable. When I supply a file that doesn't work, I don't really know why it's giving me a panic on making a slice -- but I do understand that an unmarshalling error probably comes from an invalid data stream. It's also a good idea to remove any panic calls in a library, from what most documentation says.

The deferral seems like the smoothest way to avoid any issues, as it's not clear if the maximum size is actually the maximum size (it crashed for me with a call to create a slice of size `131129665872044490`, which is actually ~1% of the actual max length of a slice).