### PR TITLE
fix NextClear out of range problem

### DIFF
--- a/bitset.go
+++ b/bitset.go
@@ -241,13 +241,15 @@ func (b *BitSet) NextClear(i uint) (uint, bool) {
 	w := b.set[x]
 	w = w >> (i & (wordSize - 1))
 	wA := allBits >> (i & (wordSize - 1))
-	if w != wA {
-		return i + trailingZeroes64(^w), true
+	index := i + trailingZeroes64(^w)
+	if w != wA && index < b.length {
+		return index, true
 	}
 	x++
 	for x < len(b.set) {
-		if b.set[x] != allBits {
-			return uint(x)*wordSize + trailingZeroes64(^b.set[x]), true
+		index = uint(x)*wordSize + trailingZeroes64(^b.set[x])
+		if b.set[x] != allBits && index < b.length {
+			return index, true
 		}
 		x++
 	}

--- a/bitset_test.go
+++ b/bitset_test.go
@@ -148,6 +148,15 @@ func TestNextClear(t *testing.T) {
 	if !found || next != 73 {
 		t.Errorf("Found next clear bit as %d, it should have been 73", next)
 	}
+
+	v = New(100)
+	for i := uint(0); i != 100; i++ {
+		v.Set(i)
+	}
+	next, found = v.NextClear(0)
+	if found || next != 0 {
+		t.Errorf("Found next clear bit as %d, it should have return (0, false)", next)
+	}
 }
 
 func TestIterate(t *testing.T) {


### PR DESCRIPTION
when we come to the last uint64 digit in NextClear,  maybe we should be aware that not all bits of this one are included.
For example, v:= bitset.New(100), only the first 36 bits of the last uint64 should be available. Otherwise, after 

       for i := uint(0); i != 100; i++ {
               v.Set(i)
       }

would be somehow wired to return the 101th bit as an unset bit since the user only created a 100 length bitset.
