### PR TITLE
Add Reset function to reuse existing BitSet

### DIFF
--- a/bitset.go
+++ b/bitset.go
@@ -77,7 +77,14 @@ func (b *BitSet) safeSet() []uint64 {
 
 // From is a constructor used to create a BitSet from an array of integers
 func From(buf []uint64) *BitSet {
-	return &BitSet{uint(len(buf)) * 64, buf}
+	return &BitSet{length(buf), buf}
+}
+
+// Reset resets the Bitset to an array of integers
+func (b *BitSet) Reset(buf []uint64) *BitSet {
+	b.length = length(buf)
+	b.set = buf
+	return b
 }
 
 // Bytes returns the bitset as array of integers
@@ -115,6 +122,10 @@ func New(length uint) (bset *BitSet) {
 // Cap returns the total possible capacity, or number of bits
 func Cap() uint {
 	return ^uint(0)
+}
+
+func length(buf []uint64) uint {
+	return uint(len(buf)) * 64
 }
 
 // Len returns the length of the BitSet in words

--- a/bitset_test.go
+++ b/bitset_test.go
@@ -945,6 +945,30 @@ func TestFrom(t *testing.T) {
 	}
 }
 
+func TestReset(t *testing.T) {
+	b := From([]uint64{2, 3, 5, 7, 11})
+	u := []uint64{1, 2, 3}
+	r := b.Reset(u)
+	outType := fmt.Sprintf("%T", r)
+	expType := "*bitset.BitSet"
+	if outType != expType {
+		t.Error("Expecting type: ", expType, ", gotf:", outType)
+		return
+	}
+	if r != b {
+		t.Error("The Bitset should be reused")
+		return
+	}
+	if r.length != 192 {
+		t.Error("Unexpected length: ", r.length)
+		return
+	}
+	if &r.set[0] != &u[0] {
+		t.Error("The slices should be pointing to the same address")
+		return
+	}
+}
+
 func TestBytes(t *testing.T) {
 	b := new(BitSet)
 	c := b.Bytes()


### PR DESCRIPTION
I have a use case where I need to decompress the bit mask on a hot path, would really like to reset the underlying words in the BitSet rather than calling From and create a new BitSet every time. 

If there is a better way to reuse the BitSet, please let me know.