### PR TITLE
Fix Equal() on a nil bitset receiver

### DIFF
--- a/bitset.go
+++ b/bitset.go
@@ -475,12 +475,12 @@ func (b *BitSet) Count() uint {
 	return 0
 }
 
-// Equal tests the equvalence of two BitSets.
+// Equal tests the equivalence of two BitSets.
 // False if they are of different sizes, otherwise true
 // only if all the same bits are set
 func (b *BitSet) Equal(c *BitSet) bool {
-	if c == nil {
-		return false
+	if c == nil || b == nil {
+		return c == b
 	}
 	if b.length != c.length {
 		return false

--- a/bitset_test.go
+++ b/bitset_test.go
@@ -842,6 +842,15 @@ func TestEqual(t *testing.T) {
 	if !a.Equal(b) {
 		t.Error("Two empty set should be equal")
 	}
+	var x *BitSet
+	var y *BitSet
+	z := New(0)
+	if !x.Equal(y) {
+		t.Error("Two nil bitsets should be equal")
+	}
+	if x.Equal(z) {
+		t.Error("Nil receiver bitset should not be equal to non-nil bitset")
+	}
 }
 
 func TestUnion(t *testing.T) {


### PR DESCRIPTION
If a calling nil Bitset is Equal'd with a non-nil Bitset, a nil dereference occurs. Additionally, two nil Bitsets are considered equal.

To reproduce:

https://play.golang.org/p/fTCzBkpaFcG